### PR TITLE
Fix applying patch when it's first in line

### DIFF
--- a/src/rapidquilt/main.rs
+++ b/src/rapidquilt/main.rs
@@ -213,7 +213,7 @@ fn cmd_push<'a, F: Iterator<Item = &'a String>>(matches: &Matches, mut free_args
         PushGoal::Count(n) => std::cmp::min(first_patch + n, series_patches.len()),
         PushGoal::UpTo(patch_filename) => {
             if let Some(index) = series_patches.iter().position(|item| item.filename == patch_filename) {
-                if index <= first_patch {
+                if index < first_patch {
                     return Err(format_err!("Patch already applied: {:?}", patch_filename));
                 }
                 index + 1


### PR DESCRIPTION
When pushing a specific patch rapidquilt validates it's not yet applied
by comparing its position in the series against the next patch to apply.
It fails to do so if the provided patch is the next in line in the
series, as it mistakenly includes that index as one of the ones to
avoid.

Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>