### PR TITLE
Update rayon to 1.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.50"
 memchr = { version = "2.2.0", features = ["libc"] }
 nom = "4.2.2"
 pathfinding = "1.1.12"
-rayon = "1.0.3"
+rayon = "1.5.0"
 seahash = "3.0.6"
 smallvec = "0.6.9"
 strsim = "0.8.0"


### PR DESCRIPTION
A newer version of rust exposed a segfault in rayon. Using the latest
rayon version fixes this.

Fixes: https://github.com/openSUSE/rapidquilt/issues/13