### PR TITLE
Fix unnecessary parentheses warning

### DIFF
--- a/src/libpatch/patch/mod.rs
+++ b/src/libpatch/patch/mod.rs
@@ -259,7 +259,7 @@ fn try_apply_hunk<'a, 'hunk>(
             //             previous hunk.."
             HunkPosition::Middle => hunk_view.remove_target_line() + last_hunk_offset,
 
-            HunkPosition::End => (modified_file.content.len() as isize - remove_content.len() as isize),
+            HunkPosition::End => modified_file.content.len() as isize - remove_content.len() as isize,
         },
 
         // In rollback mode, take it from the report


### PR DESCRIPTION
warning: unnecessary parentheses around match arm expression
   --> /home/hramrach/rapidquilt/src/libpatch/patch/mod.rs:262:34
    |
262 |             HunkPosition::End => (modified_file.content.len() as isize - remove_content.len() as isize),
    |                                  ^                                                                    ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
262 -             HunkPosition::End => (modified_file.content.len() as isize - remove_content.len() as isize),
262 +             HunkPosition::End => modified_file.content.len() as isize - remove_content.len() as isize,
    |

Signed-off-by: Michal Suchanek <msuchanek@suse.de>