### PR TITLE
Fix clippy performance warnings

### DIFF
--- a/src/rapidquilt/apply/parallel.rs
+++ b/src/rapidquilt/apply/parallel.rs
@@ -375,7 +375,7 @@ pub fn apply_patches<'config, 'arena>(config: &'config ApplyConfig, arena: &'are
         for text_file_patch in text_patch.file_patches.drain(..) {
             // Note that we can dispatch by `old_filename` or `new_filename`, we
             // made sure that both will be assigned to the same `thread_id`.
-            let thread_id = filename_to_thread_id[text_file_patch.old_filename().or(text_file_patch.new_filename()).unwrap()];
+            let thread_id = filename_to_thread_id[text_file_patch.old_filename().or_else(|| text_file_patch.new_filename()).unwrap()];
             text_file_patches_per_thread[thread_id].push((index, text_file_patch));
         }
     }

--- a/src/rapidquilt/cmd.rs
+++ b/src/rapidquilt/cmd.rs
@@ -247,7 +247,7 @@ fn cmd_push<'a, F: Iterator<Item = &'a String>>(matches: &Matches, mut free_args
         .or_else(|| env::var("RAPIDQUILT_THREADS").ok())
         .and_then(|value_txt| Some(value_txt.parse::<usize>()))
         .transpose().context("Parsing number of threads")?
-        .unwrap_or(rayon::current_num_threads());
+        .unwrap_or_else(rayon::current_num_threads);
 
     let apply_result = if num_threads <= 1 {
         apply_patches(&config, &*arena, &analyses)?


### PR DESCRIPTION
Arguments passed to `Option::or()` and `Option::unwrap_or()` are eagerly evaluated (see [here](https://doc.rust-lang.org/std/option/enum.Option.html#method.or) and [here](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or)). Use `or_else()` and `unwrap_or_else()` to avoid eager calls in closure arguments.

These are identified by clippy by running:
`cargo clippy -- --allow clippy::all --warn clippy::perf`