### PR TITLE
Simplify error propagation

### DIFF
--- a/src/rapidquilt/apply/common.rs
+++ b/src/rapidquilt/apply/common.rs
@@ -284,14 +284,13 @@ pub fn save_backup_file(config: &ApplyConfig,
         println!("Saving backup file {:?}", path);
     }
 
-    (|| -> Result<(), io::Error> { // TODO: Replace me with try-block when stable. (feature "try_blocks")
-        let real_path = config.base_dir.join(&path);
-        // NOTE(unwrap): We know that there is a parent; we built it ourselves.
-        let path_parent = real_path.parent().unwrap();
-
-        fs::create_dir_all(path_parent)?;
-        original_file.write_to(&mut File::create(real_path)?)
-    })().with_context(|_| ApplyError::SaveQuiltBackupFile { filename: path })?;
+     let real_path = config.base_dir.join(&path);
+    // NOTE(unwrap): We know that there is a parent; we built it ourselves.
+    let path_parent = real_path.parent().unwrap();
+    fs::create_dir_all(path_parent)
+        .and_then(|_| File::create(real_path))
+        .and_then(|mut f| original_file.write_to(&mut f))
+        .with_context(|_| ApplyError::SaveQuiltBackupFile { filename: path })?;
 
     Ok(())
 }

--- a/src/rapidquilt/apply/sequential.rs
+++ b/src/rapidquilt/apply/sequential.rs
@@ -37,11 +37,10 @@ pub fn apply_patches<'a, 'arena>(config: &'a ApplyConfig, arena: &'arena dyn Are
             println!("Patch: {:?}", series_patch.filename);
         }
 
-        let patch = (|| -> Result<_, Error> { // TODO: Replace me with try-block once it is stable. (feature "try_blocks")
-            let data = arena.load_file(&config.patches_path.join(&series_patch.filename))?;
-            let patch = parse_patch(&data, series_patch.strip, false)?;
-            Ok(patch)
-        })().with_context(|_| ApplyError::PatchLoad { patch_filename: config.series_patches[index].filename.clone() })?;
+        let patch = arena.load_file(&config.patches_path.join(&series_patch.filename))
+            .map_err(|err| err.into())
+            .and_then(|data| parse_patch(&data, series_patch.strip, false))
+            .with_context(|_| ApplyError::PatchLoad { patch_filename: config.series_patches[index].filename.clone() })?;
 
         let mut any_report_failed = false;
 


### PR DESCRIPTION
A couple of patches simplifying error handling that should not introduce any functional changes.

###  Avoid the need of try_blocks

Remove a few TODOs by avoiding the use of closures that return Result types (aka poor-man's try blocks). Instead, use idiomatic high-level function chains, which should improve readability quite a bit. The patch also removes the future need of `try_blocks`, once they become stable (rust-lang/rust#31436).

In other words, instead of doing this:

```rust
let result = (|| -> Result<(), io::Error> {
	let first = fn1()?;
	let second = fn2(first)?;
	fn3(second)
})()?;
```

We can simply do:

```rust
let result = fn1()
	.and_then(|first| fn2(first))
	.and_then(|second| fn3(second))?;
```

Although the changes in `src/rapidquilt/cmd.rs` are slightly bigger, they follow the same structure.

### apply/parallel: use question mark operator where possible

Replaces a few instances of the following pattern with the use of the `?` operator, which is equivalent.

```rust
if let Err(err) = function_call() {
	return Err(err);
}
```
